### PR TITLE
[`MINOR`] Temp fix for self hosted runners flash failed bug

### DIFF
--- a/.github/workflows/hardware.yml
+++ b/.github/workflows/hardware.yml
@@ -16,5 +16,6 @@ jobs:
             - run: cmake --version || sudo apt install -y cmake
             - run: arm-none-eabi-gcc --version || sudo apt install -y gcc-arm-none-eabi
             # Build the project and flash it
+            - run: sleep 1 # add a sleep command so that we wait out the blocking of the device
             - run: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=../cmake/arm-none-eabi-gcc-toolchain.cmake .. && make -j`nproc` && st-flash write OBC.bin 0x8000000
 

--- a/.github/workflows/hardware.yml
+++ b/.github/workflows/hardware.yml
@@ -17,5 +17,5 @@ jobs:
             - run: arm-none-eabi-gcc --version || sudo apt install -y gcc-arm-none-eabi
             # Build the project and flash it
             - run: sleep 1 # add a sleep command so that we wait out the blocking of the device
-            - run: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=../cmake/arm-none-eabi-gcc-toolchain.cmake .. && make -j`nproc` && st-flash write OBC.bin 0x8000000
+            - run: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=../cmake/arm-none-eabi-gcc-toolchain.cmake .. && make -j`nproc` && st-flash write OBC.bin 0x8000000 || st-flash write OBC.bin 0x8000000
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,7 @@
 - Added CLion as a supported `IDE`. ([#10](https://github.com/Aerospace-ASP/Firmware/pull/10))
 - Added Dockerfiles for the projects environment to Docker Hub. ([#10](https://github.com/Aerospace-ASP/Firmware/pull/10))
 - Added a basic CI configuration with self hosted runners for testing. ([#10](https://github.com/Aerospace-ASP/Firmware/pull/10))
+
+### Fixed
+
+- Added a temporary fix for the flashing failure in the hardware CI job by retrying it once and adding 1 second delay. ([#36](https://github.com/Aerospace-ASP/Firmware/issues/36))


### PR DESCRIPTION
### Proposed changes
* Added a temporary fix for the flashing error by trying to rerun the flashing command. Because The issue occurs with every second run it should temporarily be solved although it should be investigated further. Additionally a one second delay was added right before flashing.
```bash
st-flash write OBC.bin 0x8000000 || st-flash write OBC.bin 0x8000000
```


### Resolves issue/task
* https://github.com/Aerospace-ASP/Firmware/issues/36

### Checklist
<!-- * [ ] Unit Tests (not applicable for now) -->
* [x] Connect all issues, and project boards, add labels, assign people to the PR and the issue, etc.
* [x] Make sure that the name of the PR follows: [`MINOR` or `TASK CODE`] Some short description
* [x] Make sure that the PR description and title contain "Draft: " at the beginning if its not yet ready
* [x] Make sure that this template is properly filled in and appropriate parts deleted
* [x] Make sure you are merging your feature branch to `develop`
