### PR TITLE
enable inline suppression of warnings

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,4 +14,4 @@ jobs:
             - name: Install cppcheck
               run: sudo apt-get install -y cppcheck
             - name: Run cppcheck
-              run: cppcheck -ibuild/CMakeFiles/ -iprj/ -i3rdparty -isrc/bsp/ --enable=all --inconclusive --library=posix  . -I ./3rdparty -I prj -I ./src/bsp/  --error-exitcode=1
+              run: cppcheck -ibuild/CMakeFiles/ -iprj/ -i3rdparty -isrc/bsp/ --enable=all --inconclusive --library=posix  . -I ./3rdparty -I prj -I ./src/bsp/  --error-exitcode=1 --inline-suppr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added a basic CI configuration with self hosted runners for testing. ([#10](https://github.com/Aerospace-ASP/Firmware/pull/10))
 - Added an issue/task template ([#44](https://github.com/Aerospace-ASP/Firmware/pull/44))
 - Added a PR template ([#40](https://github.com/Aerospace-ASP/Firmware/issues/40))
+- Added an ability to manually suppress warnings for cppcheck ([#51](https://github.com/Aerospace-ASP/Firmware/issues/51))
 
 ### Fixed
 


### PR DESCRIPTION
### Proposed changes

Enable inline suppressing of warnings for cppcheck CI job

<!-- Delete these comments later -->
<!-- Example -->
<!-- * Add a change 1 and some description for command called `my-command`

    ```cpp
    // Releated code example

    int mian()
    {
        int a = 10;
    }
    ```

* Add a change 2

    (Here is an additional tab)Reletead description to the change of a photo/screenshot of something graphical -->

### Resolves issue/task

 Fix cpplint CI job ([#51](https://github.com/PWr-Aerospace/based-board-firmware/issues/51))

### Checklist

<!-- * [ ] Unit Tests (not applicable for now) -->
* [ ] Adjust arguments of cppcheck in CI job
